### PR TITLE
build: add darwin support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,6 @@ builds:
     - id: discovery
       goos:
         - linux
-        - darwin
       goarch:
         - amd64
       main: ./cmd/discovery/
@@ -21,6 +20,15 @@ builds:
         - amd64
       main: ./cmd/discoveryd/
       binary: discoveryd
+      env:
+        - CGO_ENABLED=0
+    - id: discovery-darwin
+      goos:
+        - darwin
+      goarch:
+        - amd64
+      main: ./cmd/discovery/
+      binary: discovery
       env:
         - CGO_ENABLED=0
 nfpms:
@@ -63,6 +71,39 @@ nfpms:
       description: Service discovery for prometheus with etcd backend.
       license: Die Schweizerische Post - PostFinance
       bindir: /usr/bin
+archives:
+  - id: linux
+    builds:
+      - discovery
+      - discoveryd
+    replacements:
+      "386": 32bit
+      amd64: x86_64
+      arm: ARM
+      arm64: ARM64
+      darwin: macOS
+      dragonfly: DragonFlyBSD
+      freebsd: FreeBSD
+      linux: Linux
+      netbsd: NetBSD
+      openbsd: OpenBSD
+      windows: Windows
+  - id: darwin
+    builds:
+      - discovery-darwin
+    allow_different_binary_count: true
+    replacements:
+      "386": 32bit
+      amd64: x86_64
+      arm: ARM
+      arm64: ARM64
+      darwin: macOS
+      dragonfly: DragonFlyBSD
+      freebsd: FreeBSD
+      linux: Linux
+      netbsd: NetBSD
+      openbsd: OpenBSD
+      windows: Windows
 checksum:
     name_template: checksums.txt
 dockers:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ builds:
     - id: discovery
       goos:
         - linux
+        - darwin
       goarch:
         - amd64
       main: ./cmd/discovery/


### PR DESCRIPTION
This PR adds a darwin build for the discovery tool. It also adds an archive for it.

I also needed to add the `allow_different_binary_count: true` option so it only contains the `discovery` and not the `discoveryd` binary, else goreleaser is complaining with error:

```
release failed after 8.75s error=invalid archive: 0: archive has different count of built binaries for each platform, which may cause your users confusion. Please make sure all builds used have the same set of goos/goarch/etc or split it into multiple archives
```

I am not building the `discoveryd` binary because 1. I don't need it, and 2. it causes build errors:

```
release failed after 38.49s error=failed to build for darwin_amd64: # github.com/postfinance/discovery/internal/cmd/server
internal/cmd/server/exporter.go:48:15: one.Lock undefined (type *single.Single has no field or method Lock)
internal/cmd/server/exporter.go:53:16: one.Unlock undefined (type *single.Single has no field or method Unlock)
```

and I'm too lazy to fix it :)